### PR TITLE
Using RouterContext instead of deprecated IRouterContext

### DIFF
--- a/src/base_middleware.ts
+++ b/src/base_middleware.ts
@@ -1,11 +1,10 @@
 import { injectable } from "inversify";
-import * as Router from "koa-router";
-import { interfaces } from "./interfaces";
+import { RouterContext } from "koa-router";
 
 @injectable()
 export abstract class BaseMiddleware implements BaseMiddleware {
     public abstract handler(
-        ctx: Router.IRouterContext,
+        ctx: RouterContext,
         next: () => Promise<any>
     ): any;
 }

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -1,5 +1,5 @@
 import * as Koa from "koa";
-import * as Router from "koa-router";
+import { RouterContext } from "koa-router";
 import { interfaces as inversifyInterfaces } from "inversify";
 import { PARAMETER_TYPE } from "./constants";
 
@@ -52,7 +52,7 @@ namespace interfaces {
     }
 
     export interface KoaRequestHandler {
-        (ctx: Router.IRouterContext, next: () => Promise<any>): any;
+        (ctx: RouterContext, next: () => Promise<any>): any;
     }
 
     export interface Principal {
@@ -65,7 +65,7 @@ namespace interfaces {
     }
 
     export interface AuthProvider {
-        getPrincipal(ctx: Router.IRouterContext): Promise<Principal>;
+        getPrincipal(ctx: RouterContext): Promise<Principal>;
     }
 
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -76,7 +76,7 @@ export class InversifyKoaServer {
         const _self = this;
 
         // at very first middleware set the principal to the context state
-        this._app.use(async (ctx: Router.IRouterContext, next: () => Promise<any>) => {
+        this._app.use(async (ctx: Router.RouterContext, next: () => Promise<any>) => {
             ctx.state.principal = await _self._getCurrentPrincipal(ctx);
             await next();
         });
@@ -170,7 +170,7 @@ export class InversifyKoaServer {
     }
 
     private authorizationHandlerFactory(requiredRoles: string[]): interfaces.KoaRequestHandler {
-            return async (ctx: Router.IRouterContext, next: () => Promise<any>) => {
+            return async (ctx: Router.RouterContext, next: () => Promise<any>) => {
                 let isAuthenticated = false;
                 let isAuthorized = false;
 
@@ -209,7 +209,7 @@ export class InversifyKoaServer {
 
                 if (middlewareInstance instanceof BaseMiddleware) {
                     const _self = this;
-                    return function(ctx: Router.IRouterContext, next: () => Promise<any>) {
+                    return function(ctx: Router.RouterContext, next: () => Promise<any>) {
                         return middlewareInstance.handler(ctx, next);
                     };
                 } else {
@@ -225,7 +225,7 @@ export class InversifyKoaServer {
     private handlerFactory(controllerName: any, key: string,
         parameterMetadata: interfaces.ParameterMetadata[]): interfaces.KoaRequestHandler {
         // this function works like another top middleware to extract and inject arguments
-        return async (ctx: Router.IRouterContext, next: () => Promise<any>) => {
+        return async (ctx: Router.RouterContext, next: () => Promise<any>) => {
             let args = this.extractParameters(ctx, next, parameterMetadata);
             let result: any = await this._container.getNamed(TYPE.Controller, controllerName)[key](...args);
 
@@ -238,7 +238,7 @@ export class InversifyKoaServer {
         };
     }
 
-    private extractParameters(ctx: Router.IRouterContext, next: () => Promise<any>,
+    private extractParameters(ctx: Router.RouterContext, next: () => Promise<any>,
         params: interfaces.ParameterMetadata[]): any[] {
         let args = [];
         if (!params || !params.length) {
@@ -279,7 +279,7 @@ export class InversifyKoaServer {
         }
     }
 
-    private async _getCurrentPrincipal(ctx: Router.IRouterContext): Promise<interfaces.Principal> {
+    private async _getCurrentPrincipal(ctx: Router.RouterContext): Promise<interfaces.Principal> {
         if (this._AuthProvider !== undefined) {
             const authProvider = this._container.get<interfaces.AuthProvider>(TYPE.AuthProvider);
             return await authProvider.getPrincipal(ctx);


### PR DESCRIPTION
IRouterContext (deprecated) was replaced by RouterContext

## Description
This change removes IRouterContext interface and now use RouterContext (change recommended by koa-router doc).

## Related Issue

## Motivation and Context
Avoid using deprecated interface

## How Has This Been Tested?
I ran yarn test script, but is failing

## Types of changes
- [ x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ x  ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
